### PR TITLE
feat: WebMCP document.modelContext migration and annotation type improvements

### DIFF
--- a/storefront/src/lib/webmcp/is-supported.ts
+++ b/storefront/src/lib/webmcp/is-supported.ts
@@ -1,3 +1,7 @@
+interface ModelContext {
+  registerTool?: (tool: unknown) => void
+}
+
 export const isWebMCPSupported = (): boolean => {
   if (typeof window === "undefined") return false
 
@@ -7,13 +11,9 @@ export const isWebMCPSupported = (): boolean => {
 
   if (!window.isSecureContext) return false
 
-  const nav = navigator as Navigator & {
-    modelContext?: {
-      registerTool?: (tool: unknown) => void
-    }
-  }
+  const modelContext =
+    (document as Document & { modelContext?: ModelContext }).modelContext ||
+    (navigator as Navigator & { modelContext?: ModelContext }).modelContext
 
-  return (
-    !!nav.modelContext && typeof nav.modelContext.registerTool === "function"
-  )
+  return !!modelContext && typeof modelContext.registerTool === "function"
 }

--- a/storefront/src/lib/webmcp/register-tools.ts
+++ b/storefront/src/lib/webmcp/register-tools.ts
@@ -20,6 +20,7 @@ interface Navigator extends globalThis.Navigator {
         execute: (input: unknown, client: WebMCPClient) => Promise<unknown>
         annotations?: {
           readOnlyHint?: boolean
+          untrustedContentHint?: boolean
         }
       },
       options?: { signal?: AbortSignal }
@@ -44,6 +45,7 @@ export const registerWebMCPTools = (router?: AppRouterInstance) => {
       inputSchema: object
       annotations?: {
         readOnlyHint?: boolean
+        untrustedContentHint?: boolean
       }
       handler: (
         input: unknown,

--- a/storefront/src/lib/webmcp/register-tools.ts
+++ b/storefront/src/lib/webmcp/register-tools.ts
@@ -10,23 +10,29 @@ import { cartManageTool } from "./tools/cart"
 import { WebMCPClient } from "./types"
 import { applyPromotionTool, removePromotionTool } from "./tools/promotion"
 
-interface Navigator extends globalThis.Navigator {
-  modelContext: {
-    registerTool: (
-      tool: {
-        name: string
-        description: string
-        inputSchema: object
-        execute: (input: unknown, client: WebMCPClient) => Promise<unknown>
-        annotations?: {
-          readOnlyHint?: boolean
-          untrustedContentHint?: boolean
-        }
-      },
-      options?: { signal?: AbortSignal }
-    ) => void
-    unregisterTool?: (name: string) => void
-  }
+interface ModelContext {
+  registerTool: (
+    tool: {
+      name: string
+      description: string
+      inputSchema: object
+      execute: (input: unknown, client: WebMCPClient) => Promise<unknown>
+      annotations?: {
+        readOnlyHint?: boolean
+        untrustedContentHint?: boolean
+      }
+    },
+    options?: { signal?: AbortSignal }
+  ) => void
+  unregisterTool?: (name: string) => void
+}
+
+interface DocumentWithModelContext extends globalThis.Document {
+  modelContext?: ModelContext
+}
+
+interface NavigatorWithModelContext extends globalThis.Navigator {
+  modelContext?: ModelContext
 }
 
 export const registerWebMCPTools = (router?: AppRouterInstance) => {
@@ -35,7 +41,15 @@ export const registerWebMCPTools = (router?: AppRouterInstance) => {
     return () => {}
   }
 
-  const modelContext = (navigator as unknown as Navigator).modelContext
+  const modelContext =
+    (document as DocumentWithModelContext).modelContext ||
+    (navigator as NavigatorWithModelContext).modelContext
+
+  if (!modelContext) {
+    console.info("modelContext unavailable, skipping registration")
+    return () => {}
+  }
+
   const controller = new AbortController()
 
   try {

--- a/storefront/src/lib/webmcp/register-tools.ts
+++ b/storefront/src/lib/webmcp/register-tools.ts
@@ -7,7 +7,7 @@ import {
 } from "./tools/checkout"
 import { productsSearchTool } from "./tools/products-search"
 import { cartManageTool } from "./tools/cart"
-import { WebMCPClient } from "./types"
+import { WebMCPClient, WebMCPToolAnnotations } from "./types"
 import { applyPromotionTool, removePromotionTool } from "./tools/promotion"
 
 interface ModelContext {
@@ -17,10 +17,7 @@ interface ModelContext {
       description: string
       inputSchema: object
       execute: (input: unknown, client: WebMCPClient) => Promise<unknown>
-      annotations?: {
-        readOnlyHint?: boolean
-        untrustedContentHint?: boolean
-      }
+      annotations?: WebMCPToolAnnotations
     },
     options?: { signal?: AbortSignal }
   ) => void
@@ -57,10 +54,7 @@ export const registerWebMCPTools = (router?: AppRouterInstance) => {
       name: string
       description: string
       inputSchema: object
-      annotations?: {
-        readOnlyHint?: boolean
-        untrustedContentHint?: boolean
-      }
+      annotations?: WebMCPToolAnnotations
       handler: (
         input: unknown,
         context?: {

--- a/storefront/src/lib/webmcp/tools/cart.ts
+++ b/storefront/src/lib/webmcp/tools/cart.ts
@@ -150,6 +150,10 @@ export const cartManage = async (
 export const cartManageTool: WebMCPTool<CartManageInput, CartSnapshot> = {
   name: "cart.manage",
   description: "Manage shopping cart (add, remove, update, view)",
+  annotations: {
+    readOnlyHint: false,
+    untrustedContentHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {

--- a/storefront/src/lib/webmcp/tools/checkout.ts
+++ b/storefront/src/lib/webmcp/tools/checkout.ts
@@ -175,6 +175,7 @@ export const navigateToProductTool: WebMCPTool<
     "Navigate to product detail page, optionally preselect options. For products with Material and Color, Material must be set before Color.",
   annotations: {
     readOnlyHint: false,
+    untrustedContentHint: true,
   },
   inputSchema: {
     type: "object",
@@ -219,6 +220,7 @@ export const checkoutPrepareTool: WebMCPTool<
     "Validate that the shopping cart has items and navigate to the checkout page. Performs pre-checkout validation (checks cart exists and is not empty) before proceeding. Returns error if cart is missing or empty.",
   annotations: {
     readOnlyHint: false,
+    untrustedContentHint: true,
   },
   inputSchema: {
     type: "object",

--- a/storefront/src/lib/webmcp/tools/products-search.ts
+++ b/storefront/src/lib/webmcp/tools/products-search.ts
@@ -165,6 +165,7 @@ export const productsSearchTool: WebMCPTool<
     "Search and retrieve product information (price, variants, options, categories, tags) with optional filters and sorting.",
   annotations: {
     readOnlyHint: true,
+    untrustedContentHint: true,
   },
   inputSchema: {
     type: "object",

--- a/storefront/src/lib/webmcp/tools/promotion.ts
+++ b/storefront/src/lib/webmcp/tools/promotion.ts
@@ -106,6 +106,7 @@ export const applyPromotionTool: WebMCPTool<PromotionInput, CartSnapshot> = {
     "Apply a discount/promotion code to the shopping cart. Returns updated cart with applied discount, including new subtotal, total, and discount amount. Common error codes: MISSING_CODE (promotion code is required), CART_MISSING (no active cart found), APPLY_FAILED (failed to apply promotion code).",
   annotations: {
     readOnlyHint: false,
+    untrustedContentHint: true,
   },
   inputSchema: {
     type: "object",
@@ -128,6 +129,7 @@ export const removePromotionTool: WebMCPTool<PromotionInput, CartSnapshot> = {
     "Remove a previously applied discount/promotion code from the shopping cart. Returns updated cart with recalculated totals after discount removal. Use this when the user wants to replace a code or remove an applied discount.",
   annotations: {
     readOnlyHint: false,
+    untrustedContentHint: true,
   },
   inputSchema: {
     type: "object",

--- a/storefront/src/lib/webmcp/types.ts
+++ b/storefront/src/lib/webmcp/types.ts
@@ -31,6 +31,7 @@ export interface WebMCPTool<TInput, TData> {
   inputSchema: Record<string, unknown>
   annotations?: {
     readOnlyHint?: boolean
+    untrustedContentHint?: boolean
   }
   handler: (
     input: TInput,

--- a/storefront/src/lib/webmcp/types.ts
+++ b/storefront/src/lib/webmcp/types.ts
@@ -57,3 +57,5 @@ export interface CartSnapshot {
     discount_codes?: string[]
   }
 }
+
+export type WebMCPToolAnnotations = WebMCPTool<unknown, unknown>["annotations"]


### PR DESCRIPTION
Migrate WebMCP to use `document.modelContext` as the primary context source
with `navigator.modelContext` as a fallback, following the Chrome 150 deprecation.
Also improves type safety around tool annotations.

- Add `untrustedContentHint` support to WebMCP tool annotations
- Use `document.modelContext` with `navigator` fallback for Chrome 150+ compatibility
- Extract `WebMCPToolAnnotations` type to avoid annotation shape drift